### PR TITLE
Remove redundant U8 assert

### DIFF
--- a/source/librii/u8/U8.cpp
+++ b/source/librii/u8/U8.cpp
@@ -59,7 +59,6 @@ rvlArchiveHeaderGetFileData(const rvlArchiveHeader* self) {
 }
 
 template <typename T> bool SafeMemCopy(T& dest, std::span<const u8> data) {
-  assert(data.size_bytes() >= sizeof(T));
   if (data.size_bytes() < sizeof(T)) {
     std::fill((u8*)&dest, (u8*)(&dest + 1), 0);
     return false;


### PR DESCRIPTION
Something I found while working out how I will eventually add the RARC support. This assertion shouldn't exist as the function already handles the case it covers.