### PR TITLE
Fix build regressions on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,9 @@ if (APPLE)
 endif()
 
 CPMAddPackage("gh:corrosion-rs/corrosion@0.3.2")
-find_package(Corrosion REQUIRED)
+if(NOT UNIX)
+  find_package(Corrosion REQUIRED)
+endif()
 
 corrosion_import_crate(MANIFEST_PATH source/rust/Cargo.toml)
 

--- a/source/cli/CMakeLists.txt
+++ b/source/cli/CMakeLists.txt
@@ -58,6 +58,17 @@ elseif (NOT UNIX)
     ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlib.a
     ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlibstatic.a
   )
+elseif (UNIX)
+  find_library(ASSIMP_LIBRARY NAMES libassimp.so PATHS /usr/lib)
+  find_library(GLFW3_LIBRARY NAMES libglfw.so PATHS /usr/lib)
+  find_library(FREETYPE_LIBRARY NAMES libfreetype.so PATHS /usr/lib)
+  find_library(BZIP2_LIBRARY NAMES libbz2.so PATHS /usr/lib)
+  target_link_libraries(cli PUBLIC
+    ${ASSIMP_LIBRARY}
+    ${GLFW3_LIBRARY}
+    ${FREETYPE_LIBRARY}
+    ${BZIP2_LIBRARY}
+  )
 endif()
  
 # DLLs for windows

--- a/source/cli/Rszst.cpp
+++ b/source/cli/Rszst.cpp
@@ -12,6 +12,7 @@
 #include <plugins/j3d/J3dIo.hpp>
 #include <plugins/rhst/RHSTImporter.hpp>
 #include <sstream>
+#include <mutex>
 
 namespace riistudio {
 const char* translateString(std::string_view str) { return str.data(); }

--- a/source/frontend/CMakeLists.txt
+++ b/source/frontend/CMakeLists.txt
@@ -117,6 +117,10 @@ elseif (NOT UNIX)
 	  ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlib.a
 	  ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlibstatic.a
 	)
+elseif (UNIX)
+	# TODO: Duplication: extract to FindX.cmake
+	find_library(BZIP2_LIBRARY NAMES libbz2.so PATHS /usr/lib)
+	target_link_libraries(frontend PUBLIC ${BZIP2_LIBRARY})
 endif()
 
 # Decentralized installers based on initialization of static objects

--- a/source/librii/CMakeLists.txt
+++ b/source/librii/CMakeLists.txt
@@ -164,7 +164,7 @@ if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND ${CMAKE_SYSTEM_NAME} MATCHES "
   )
 endif()
 
-target_link_libraries(librii PUBLIC core LibBadUIFramework PRIVATE meshoptimizer draco::draco fort range-v3 json_struct)
+target_link_libraries(librii PUBLIC core LibBadUIFramework PRIVATE meshoptimizer draco::draco fort range-v3 json_struct vendor)
 
 target_include_directories(librii
   PRIVATE

--- a/source/plugins/CMakeLists.txt
+++ b/source/plugins/CMakeLists.txt
@@ -56,4 +56,4 @@ if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND ${CMAKE_SYSTEM_NAME} MATCHES "
     ../core/common.h
   )
 endif()
-target_link_libraries(plugins PUBLIC core LibBadUIFramework PRIVATE range-v3)
+target_link_libraries(plugins PUBLIC core LibBadUIFramework librii rsl PRIVATE range-v3)

--- a/source/rsl/CMakeLists.txt
+++ b/source/rsl/CMakeLists.txt
@@ -13,4 +13,4 @@ add_library(rsl STATIC
  "Discord.cpp"
  "FFIActivity.cc"
  )
-target_link_libraries(rsl PUBLIC core range-v3 riistudio_rs)
+target_link_libraries(rsl PUBLIC core range-v3 riistudio_rs vendor)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -59,6 +59,10 @@ elseif (NOT UNIX)
 	  ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlib.a
 	  ${PROJECT_SOURCE_DIR}/../vendor/assimp/libzlibstatic.a
 	)
+elseif(UNIX)
+	# TODO: code duplication, extract FindBzip2.cmake to top level CMakeLists
+	find_library(BZIP2_LIBRARY NAMES libbz2.so PATHS /usr/lib)
+	target_link_libraries(tests PUBLIC ${BZIP2_LIBRARY})
 endif()
 
 # Decentralized installers based on initialization of static objects


### PR DESCRIPTION
Currently system libraries are found individually. Ideally external libraries are found using custom "find module" files in a top level cmake and inherited to all subdirectory CMakeLists.
https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#find-modules