### PR TITLE
[C-WBZ] Fix soundness issues and save a buffer copy

### DIFF
--- a/source/c-wbz/include/wbz_rs.h
+++ b/source/c-wbz/include/wbz_rs.h
@@ -30,11 +30,7 @@ int32_t wbzrs_decode_wu8(void* wu8_buffer, uint32_t wu8_len,
                          const char* autoadd_path);
 
 const char* wbzrs_error_to_string(int32_t ec);
-
-static inline void wbzrs_free_buffer(wbzrs_buffer* buf) {
-  free(buf->data);
-  memset(buf, 0, sizeof(*buf));
-}
+void wbzrs_free_buffer(wbzrs_buffer* buf);
 
 #ifdef __cplusplus
 }

--- a/source/c-wbz/src/buffer.rs
+++ b/source/c-wbz/src/buffer.rs
@@ -1,0 +1,40 @@
+use std::mem::ManuallyDrop;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Buffer {
+    begin: *mut u8,
+    len: usize,
+}
+
+impl Buffer {
+    /// # Safety
+    /// Buffer must have originally been created via the From<Vec<u8>> conversion.
+    pub unsafe fn into_vec(self) -> Vec<u8> {
+        unsafe {
+            Vec::from_raw_parts(self.begin, self.len, self.len)
+        }
+    }
+}
+
+impl From<Vec<u8>> for Buffer {
+    fn from(value: Vec<u8>) -> Self {
+        let mut value = ManuallyDrop::new(value);
+        value.shrink_to_fit();
+
+        // Manual Vec::into_raw_parts
+        let ptr = value.as_mut_ptr();
+        let cap = value.capacity();
+        let len = value.len();
+
+        if cap != len {
+            eprintln!("Failed to shrink {cap} to equal {len}!");
+            std::process::abort();
+        }
+
+        Buffer {
+            begin: ptr,
+            len
+        }
+    }
+}


### PR DESCRIPTION
- Add nice methods to Rust's `Buffer` to make it safer to use.
- Stops panicking out of `extern "C"`, because that's 100% UB
- Fixes shady Rust side allocation and C++ deallocation, while saving a copy of the entire buffer contents.

There should probably be some shared utils between the different rust portions of RiiStudio.